### PR TITLE
fix: update dotnet SDK versions to include specific patch versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     with:
       configuration: Release
       dotnet-sdks: |
-        8.x
-        9.x
-        10.x
+        8.0.x
+        9.0.x
+        10.0.x
 
     secrets:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/ci.yml` file. The change updates the version format for the `dotnet-sdks` configuration to use more specific versioning.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R21): Updated `dotnet-sdks` versions from `8.x`, `9.x`, and `10.x` to `8.0.x`, `9.0.x`, and `10.0.x` to ensure more precise version control.