### PR TITLE
Update copyright notices and improve code quality

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -122,6 +122,7 @@ indent_size = 2
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
+file_header_template = Copyright © https://myCSharp.de - all rights reserved
 
 # Organize usings
 dotnet_sort_system_directives_first = true

--- a/samples/HttpClientHints.Samples.AspNetCoreMvc/Controllers/HomeController.cs
+++ b/samples/HttpClientHints.Samples.AspNetCoreMvc/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.AspNetCore.Mvc;
 

--- a/samples/HttpClientHints.Samples.AspNetCoreMvc/Program.cs
+++ b/samples/HttpClientHints.Samples.AspNetCoreMvc/Program.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using MyCSharp.HttpClientHints.AspNetCore;
 

--- a/src/HttpClientHints.AspNetCore/HttpClientHintsHttpContextExtensions.cs
+++ b/src/HttpClientHints.AspNetCore/HttpClientHintsHttpContextExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -23,13 +23,13 @@ public static class HttpClientHintsHttpContextExtensions
     public static HttpClientHints GetClientHints(this HttpContext context)
     {
         // Check if client hints are already cached for this request
-        if (context.Items.TryGetValue(ClientHintsCacheKey, out var cached) && cached is HttpClientHints hints)
+        if (context.Items.TryGetValue(ClientHintsCacheKey, out object? cached) && cached is HttpClientHints hints)
         {
             return hints;
         }
-        
+
         // Create and cache new client hints
-        var newHints = context.Request.Headers.GetClientHints();
+        HttpClientHints newHints = context.Request.Headers.GetClientHints();
         context.Items[ClientHintsCacheKey] = newHints;
         return newHints;
     }
@@ -44,14 +44,14 @@ public static class HttpClientHintsHttpContextExtensions
         // User Agent
         headers.TryGetValue("User-Agent", out StringValues userAgentValues);
         string? userAgent = userAgentValues.Count > 0 ? userAgentValues[0] : null;
-        
+
         headers.TryGetValue("Sec-CH-UA", out StringValues uaValues);
         string? ua = uaValues.Count > 0 ? uaValues[0] : null;
 
         // Platform
         headers.TryGetValue("Sec-CH-UA-Platform", out StringValues platformValues);
         string? platform = platformValues.Count > 0 ? platformValues[0] : null;
-        
+
         headers.TryGetValue("Sec-CH-UA-Platform-Version", out StringValues platformVersionValues);
         string? platformVersion = platformVersionValues.Count > 0 ? platformVersionValues[0] : null;
 
@@ -66,7 +66,7 @@ public static class HttpClientHintsHttpContextExtensions
         // Device
         headers.TryGetValue("Sec-CH-UA-Model", out StringValues modelValues);
         string? model = modelValues.Count > 0 ? modelValues[0] : null;
-        
+
         headers.TryGetValue("Sec-CH-UA-Mobile", out StringValues mobileValues);
         bool? mobile = HttpClientHintsInterpreter.IsMobile(mobileValues.Count > 0 ? mobileValues[0] : null);
 

--- a/src/HttpClientHints.AspNetCore/HttpClientHintsMiddlewareConfig.cs
+++ b/src/HttpClientHints.AspNetCore/HttpClientHintsMiddlewareConfig.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 namespace MyCSharp.HttpClientHints.AspNetCore;
 

--- a/src/HttpClientHints.AspNetCore/HttpClientHintsOptions.cs
+++ b/src/HttpClientHints.AspNetCore/HttpClientHintsOptions.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 namespace MyCSharp.HttpClientHints.AspNetCore;
 

--- a/src/HttpClientHints.AspNetCore/HttpClientHintsRegistration.cs
+++ b/src/HttpClientHints.AspNetCore/HttpClientHintsRegistration.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/HttpClientHints.AspNetCore/HttpClientHintsRequestMiddleware.cs
+++ b/src/HttpClientHints.AspNetCore/HttpClientHintsRequestMiddleware.cs
@@ -1,3 +1,5 @@
+// Copyright © https://myCSharp.de - all rights reserved
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 

--- a/src/HttpClientHints/HttpClientHints.cs
+++ b/src/HttpClientHints/HttpClientHints.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.Extensions.Primitives;
 

--- a/src/HttpClientHints/HttpClientHintsInterpreter.cs
+++ b/src/HttpClientHints/HttpClientHintsInterpreter.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 namespace MyCSharp.HttpClientHints;
 

--- a/tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsHttpContextExtensionsTests.cs
+++ b/tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsHttpContextExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
@@ -12,7 +12,7 @@ public class HttpClientHintsHttpContextExtensionsTests
     public void GetClientHints_ReturnsCorrectValues_WhenHeadersArePresent()
     {
         // Arrange
-        HeaderDictionary headers = new HeaderDictionary
+        HeaderDictionary headers = new()
         {
             { "User-Agent", new StringValues("TestUserAgent") },
             { "Sec-CH-UA", new StringValues("TestUA") },
@@ -65,7 +65,7 @@ public class HttpClientHintsHttpContextExtensionsTests
     public void GetClientHints_ReturnsCorrectMobileValue_WhenMobileHeaderIsTrue()
     {
         // Arrange
-        HeaderDictionary headers = new HeaderDictionary
+        HeaderDictionary headers = new()
         {
             { "Sec-CH-UA-Mobile", new StringValues("?1") } // true
         };
@@ -81,7 +81,7 @@ public class HttpClientHintsHttpContextExtensionsTests
     public void GetClientHints_ReturnsCorrectMobileValue_WhenMobileHeaderIsFalse()
     {
         // Arrange
-        HeaderDictionary headers = new HeaderDictionary
+        HeaderDictionary headers = new()
         {
             { "Sec-CH-UA-Mobile", new StringValues("?0") } // false
         };

--- a/tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsRegistrationTests.cs
+++ b/tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsRegistrationTests.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsRequestMiddlewareTests.cs
+++ b/tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsRequestMiddlewareTests.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;

--- a/tests/HttpClientHints.UnitTests/HttpClientHintsInterpreterTests.cs
+++ b/tests/HttpClientHints.UnitTests/HttpClientHintsInterpreterTests.cs
@@ -1,4 +1,4 @@
-// Copyright © myCSharp.de - all rights reserved
+// Copyright © https://myCSharp.de - all rights reserved
 
 using Xunit;
 


### PR DESCRIPTION
This pull request includes several changes to update copyright notices and improve code consistency across multiple files.

### Copyright updates:
* Updated copyright notices to include the URL `https://myCSharp.de` instead of `myCSharp.de` in various files:
  * `.editorconfig`
  * `samples/HttpClientHints.Samples.AspNetCoreMvc/Controllers/HomeController.cs`
  * `samples/HttpClientHints.Samples.AspNetCoreMvc/Program.cs`
  * `src/HttpClientHints.AspNetCore/HttpClientHintsHttpContextExtensions.cs`
  * `src/HttpClientHints.AspNetCore/HttpClientHintsMiddlewareConfig.cs`
  * `src/HttpClientHints.AspNetCore/HttpClientHintsOptions.cs`
  * `src/HttpClientHints.AspNetCore/HttpClientHintsRegistration.cs`
  * `src/HttpClientHints.AspNetCore/HttpClientHintsRequestMiddleware.cs`
  * `src/HttpClientHints/HttpClientHints.cs`
  * `src/HttpClientHints/HttpClientHintsInterpreter.cs`
  * `tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsHttpContextExtensionsTests.cs`
  * `tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsRegistrationTests.cs`
  * `tests/HttpClientHints.AspNetCore.UnitTests/HttpClientHintsRequestMiddlewareTests.cs`
  * `tests/HttpClientHints.UnitTests/HttpClientHintsInterpreterTests.cs`

### Code consistency improvements:
* Improved type consistency in `HttpClientHintsHttpContextExtensions.cs`:
  * Changed the type of `cached` to `object?` in `GetClientHints` method
  * Explicitly declared `newHints` as `HttpClientHints` in `GetClientHints` method
* Simplified object initialization in unit tests:
  * Used target-typed new expressions for `HeaderDictionary` initialization in `HttpClientHintsHttpContextExtensionsTests.cs` [[1]](diffhunk://#diff-1cd703d9d0042a8a539a46a5bd15ac81db5b922ebcca73dabf2b90cbdbc596feL15-R15) [[2]](diffhunk://#diff-1cd703d9d0042a8a539a46a5bd15ac81db5b922ebcca73dabf2b90cbdbc596feL68-R68) [[3]](diffhunk://#diff-1cd703d9d0042a8a539a46a5bd15ac81db5b922ebcca73dabf2b90cbdbc596feL84-R84)